### PR TITLE
Generate a better footprint

### DIFF
--- a/bin/ingest_single_footprint.sh
+++ b/bin/ingest_single_footprint.sh
@@ -38,7 +38,6 @@ ogr2ogr \
   /vsistdout/ /vsistdin/
 
 # Update the data we just added to include info about resolution, etc.
-# ... 120 is the number of pixels to buffer; it's the sample value for rio footprint + 20%
 cat << EOF
   UPDATE footprints SET
     resolution=${resolution},
@@ -48,7 +47,6 @@ cat << EOF
     min_zoom=greatest(0, approximate_zoom - 4),
     max_zoom=20,
     source='${source}',
-    url='${transcoded_uri}',
-    wkb_geometry=ST_Multi(ST_Buffer(wkb_geometry::geography, resolution * 120)::geometry)
+    url='${transcoded_uri}'
   WHERE filename='${filename}';
 EOF

--- a/bin/process.sh
+++ b/bin/process.sh
@@ -200,7 +200,7 @@ gdalwarp -r average \
   -srcnodata $(jq -r .nodata <<< $info) \
   $intermediate ${intermediate/.tif/_small.tif}
 rio shapes --mask --as-mask --precision 6 ${intermediate/.tif/_small.tif} | \
-  jq --argjson resolution $(jq .meta.resolution <<< $meta) --arg filename "$(basename $output)" '{"type": "Feature", "properties": {"filename": $filename, "resolution": $resolution}, "geometry": {"type": "MultiPolygon", "coordinates": [.features[].geometry.coordinates]}}' | \
+  jq --argjson resolution $(jq .meta.resolution <<< $meta) --arg filename "$(basename $output).tif" '{"type": "Feature", "properties": {"filename": $filename, "resolution": $resolution}, "geometry": {"type": "MultiPolygon", "coordinates": [.features[].geometry.coordinates]}}' | \
   aws s3 cp - ${output}_footprint.json
 
 rm -f ${intermediate}*

--- a/bin/process.sh
+++ b/bin/process.sh
@@ -150,12 +150,6 @@ if [ -f ${intermediate}.msk ]; then
   #   perl -pe "s|${gdal_output}|$(basename $output)|" | \
   #   perl -pe 's|(relativeToVRT=)"0"|$1"1"|' | \
   #   aws s3 cp - ${output}.vrt
-
-  # 5. create footprint
-  >&2 echo "Generating footprint..."
-  rio shapes --mask --as-mask --sampling 100 --precision 6 --with-nodata $intermediate | \
-    perl -pe "s|$(basename $intermediate)|$(basename $output).tif|g" | \
-    aws s3 cp - ${output}_footprint.json
 else
   mask=0
 
@@ -171,15 +165,7 @@ else
   #   perl -pe "s|${gdal_output}|$(basename $output)|" | \
   #   perl -pe 's|(relativeToVRT=)"0"|$1"1"|' | \
   #   aws s3 cp - ${output}.vrt
-
-  # 4. create footprint (bounds of image)
-  >&2 echo "Generating footprint..."
-  rio shapes --mask --as-mask --sampling 100 --precision 6 --with-nodata $intermediate | \
-    perl -pe "s|$(basename $intermediate)|$(basename $output).tif|g" | \
-    aws s3 cp - ${output}_footprint.json
 fi
-
-rm -f ${intermediate}*
 
 # # 6. create thumbnail
 # >&2 echo "Generating thumbnail..."
@@ -200,10 +186,24 @@ rm -f ${intermediate}*
 # 9. create and upload metadata
 >&2 echo "Generating metadata..."
 if [ "$mask" -eq 1 ]; then
-  get_metadata.py --include-mask "${args[@]}" $output | aws s3 cp - ${output}.json
+  meta=$(get_metadata.py --include-mask "${args[@]}" $output)
 else
-  get_metadata.py "${args[@]}" $output | aws s3 cp - ${output}.json
+  meta=$(get_metadata.py "${args[@]}" $output)
 fi
+echo $meta | aws s3 cp - ${output}.json
+
+# 5. create footprint
+>&2 echo "Generating footprint..."
+info=$(rio info $intermediate)
+gdalwarp -r average \
+  -ts $[$(jq -r .width <<< $info) / 100] $[$(jq -r .height <<< $info) / 100] \
+  -srcnodata $(jq -r .nodata <<< $info) \
+  $intermediate ${intermediate/.tif/_small.tif}
+rio shapes --mask --as-mask --precision 6 ${intermediate/.tif/_small.tif} | \
+  jq --argjson resolution $(jq .meta.resolution <<< $meta) --arg filename "$(basename $output)" '{"type": "Feature", "properties": {"filename": $filename, "resolution": $resolution}, "geometry": {"type": "MultiPolygon", "coordinates": [.features[].geometry.coordinates]}}' | \
+  aws s3 cp - ${output}_footprint.json
+
+rm -f ${intermediate}*
 
 # # 10. Upload OIN metadata
 # aws s3 cp - ${output}_meta.json <<< $metadata


### PR DESCRIPTION
For #27 

- Generate metadata first so it can be used in footprints GeoJSON
- Use gdalwarp to downsample the image, then use rio shapes on the downsampled image
- Pass the output of rio shapes through jq to create a MultiPolygon and to adjust properties