### PR TITLE
Use a custom Python script to handle rio shapes output

### DIFF
--- a/bin/process.sh
+++ b/bin/process.sh
@@ -200,7 +200,7 @@ gdalwarp -r average \
   -srcnodata $(jq -r .nodata <<< $info) \
   $intermediate ${intermediate/.tif/_small.tif}
 rio shapes --mask --as-mask --precision 6 ${intermediate/.tif/_small.tif} | \
-  jq --argjson resolution $(jq .meta.resolution <<< $meta) --arg filename "$(basename $output).tif" '{"type": "Feature", "properties": {"filename": $filename, "resolution": $resolution}, "geometry": {"type": "MultiPolygon", "coordinates": [.features[].geometry.coordinates]}}' | \
+  rio_shapes_to_multipolygon.py --argfloat resolution=$(jq .meta.resolution <<< $meta) --argstr filename="$(basename $output).tif" | \
   aws s3 cp - ${output}_footprint.json
 
 rm -f ${intermediate}*

--- a/bin/rio_shapes_to_multipolygon.py
+++ b/bin/rio_shapes_to_multipolygon.py
@@ -1,0 +1,58 @@
+#!/usr/bin/env python
+# coding=utf-8
+import argparse
+import json
+import sys
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--argstr', nargs='*')
+    parser.add_argument('--argfloat', nargs='*')
+    args = parser.parse_args()
+
+    incoming = json.load(sys.stdin)
+
+    geojson = {
+        "type": "Feature",
+        "properties": {},
+        "geometry": {
+            "type": "MultiPolygon",
+            "coordinates": [],
+        }
+    }
+
+    if args.argstr:
+        for a in args.argstr:
+            k, v = a.split('=', 1)
+            geojson['properties'][k] = v
+
+    if args.argfloat:
+        for a in args.argfloat:
+            k, v = a.split('=', 1)
+            geojson['properties'][k] = float(v)
+
+    assert incoming['type'] == 'FeatureCollection', \
+        "Expecting a FeatureCollection GeoJSON object"
+
+    for feature in incoming['features']:
+        assert feature['type'] == 'Feature'
+
+        geometry = feature['geometry']
+        assert geometry['type'] in ('Polygon', 'MultiPolygon'), \
+            "Expecting Polygon or MultiPolygon features"
+
+        if geometry['type'] == 'Polygon':
+            geojson['geometry']['coordinates'].append(
+                geometry['coordinates']
+            )
+        elif geometry['type'] == 'MultiPolygon':
+            geojson['geometry']['coordinates'].extend(
+                geometry['coordinates']
+            )
+
+    json.dump(geojson, sys.stdout)
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
Instead of using a fancy `jq` command, this is a full-fledged Python command that does the same sort of thing but is smart enough to handle the difference between MultiPolygons (which `rio shapes` generates if you're on or straddling the antimeridian) and Polygons (which `rio shapes` generates normally).