### PR TITLE
Fix pyramid renderer footprints caching code

### DIFF
--- a/examples/render_pyramid.py
+++ b/examples/render_pyramid.py
@@ -143,8 +143,7 @@ def build_source_index(tile, min_zoom, max_zoom):
                         wkb_geometry,
                         ST_GeomFromText(%s, 4326)
                     )
-                    AND min_zoom <= %s
-                    AND max_zoom >= %s
+                    AND numrange(min_zoom, max_zoom) && numrange(%s, %s)
                     AND enabled = true
                 """, (bbox.to_wkt(), min_zoom, max_zoom))
 


### PR DESCRIPTION
For https://github.com/tilezen/joerd/issues/167.

The query that made to Postgres to cache the sources overlapping with the root of the pyramid to be rendered was broken in dd37b3d7867d0227477a219300f7aefff8f1300c by requiring the pyramid's requested min and max zoom to be entirely contained inside the min/max zoom for a footprint.

This change uses Postgres' [built-in range overlap operator](https://www.postgresql.org/docs/9.3/static/functions-range.html) to properly cache footprints in pyramid renderer.