### PR TITLE
Support for internal masks

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,42 +1,37 @@
 from setuptools import find_packages, setup
 
-version = '0.3.1'
+version = "0.3.1"
 
 setup(
-    name='marblecutter',
+    name="marblecutter",
     version=version,
-    description='Raster manipulation',
-    url='https://github.com/mojodna/marblecutter',
-    author='Seth Fitzsimmons',
-    author_email='seth@mojodna.net',
-    license='BSD',
+    description="Raster manipulation",
+    url="https://github.com/mojodna/marblecutter",
+    author="Seth Fitzsimmons",
+    author_email="seth@mojodna.net",
+    license="BSD",
     packages=find_packages(),
     zip_safe=False,
-    package_data={
-        'marblecutter': ['static/images/*', 'templates/*'],
-    },
+    package_data={"marblecutter": ["static/images/*", "templates/*"]},
     install_requires=[
-        'futures',
-        'haversine',
-        'mercantile',
-        'numpy',
-        'Pillow',
-        'rasterio[s3]>=1.0a12',
-        'requests',
-        'rio-pansharpen ~= 0.2.0',
-        'rio-tiler ~= 0.0.3',
-        'rio-toa',
-        'scipy',
+        "futures",
+        "haversine",
+        "mercantile",
+        "numpy",
+        "Pillow",
+        "rasterio[s3]>=1.0rc2",
+        "requests",
+        "rio-pansharpen ~= 0.2.0",
+        # TODO upgrade me
+        "rio-tiler ~= 0.0.3",
+        "rio-toa",
     ],
     # dependency_links=[
     #     'https://github.com/mapbox/rasterio/archive/master.tar.gz#egg=rasterio[s3]',
     # ],
     extras_require={
-        'color_ramp': 'matplotlib',
-        'postgis': 'psycopg2',
-        'web': [
-            'flask',
-            'flask-cors',
-        ],
+        "color_ramp": "matplotlib",
+        "postgis": "psycopg2",
+        "web": ["flask", "flask-cors"],
     },
 )


### PR DESCRIPTION
This uses the materialized alpha band that rasterio provides when a mask is available (internal or external) and no nodata value has been provided. As a result, external masks no longer need to be read explicitly and the slowdown present when using `masked=True` is bypassed.

This also removes the use of boundless reads (dropped for WarpedVRTs in rasterio@1.0b2), upgrades rasterio, and drops the scipy dependency that was being used in an attempt to clean up masked output.

@sgillies @vincentsarago thanks for your help working this out!