### PR TITLE
added support for dynamic band arithmetic via numexpr

### DIFF
--- a/marblecutter/utils.py
+++ b/marblecutter/utils.py
@@ -25,10 +25,11 @@ Source = namedtuple(
         "filename",
         "min_zoom",
         "max_zoom",
+        "expr"
     ],
 )
 Source.__new__.__defaults__ = (
-    {}, {}, {}, None, None, None, None, None, None, None, None, None
+    {}, {}, {}, None, None, None, None, None, None, None, None, None, None
 )
 
 

--- a/setup.py
+++ b/setup.py
@@ -17,6 +17,7 @@ setup(
         "future",
         "haversine",
         "mercantile",
+        "numexpr",
         "numpy",
         "Pillow",
         "rasterio[s3]>=1.0.9",


### PR DESCRIPTION
Hello.  I have submitted a PR for your consideration that adds in support for Band Arithmetic using [numexpr](https://github.com/pydata/numexpr).  This is the same library that rio-tiler uses for band expressions, which you can see here: https://github.com/cogeotiff/rio-tiler/blob/master/rio_tiler/utils.py#L783

It uses the same variables as rio-tiler: `b1`, `b2`, `b3`, etc.  However, I'm happy to change this to `A`, `B`, `C` if you prefer that.

I will also submit a PR to marblecutter-virtual for your consideration as well.

Thank you and please let me know if there is anything I should change.