### PR TITLE
Source pixels

### DIFF
--- a/marblecutter/mosaic.py
+++ b/marblecutter/mosaic.py
@@ -14,6 +14,8 @@ from .utils import Bounds, PixelCollection
 
 LOG = logging.getLogger(__name__)
 
+MAX_WORKERS = multiprocessing.cpu_count() * 5
+
 
 def composite(sources, bounds, shape, target_crs, expand):
     """Composite data from sources into a single raster covering bounds, but in
@@ -33,6 +35,8 @@ def composite(sources, bounds, shape, target_crs, expand):
     sources = recipes.preprocess(sources, resolution=resolution)
 
     def _read_window(source):
+        if hasattr(source, "pixels") and source.pixels is not None:
+            return (source, source.pixels)
         with get_source(source.url) as src:
             LOG.info(
                 "Fetching %s (%s) as band %s",
@@ -82,7 +86,7 @@ def composite(sources, bounds, shape, target_crs, expand):
 
     # iterate over available sources, sorted by decreasing "quality"
     with futures.ThreadPoolExecutor(
-        max_workers=multiprocessing.cpu_count() * 5
+        max_workers=MAX_WORKERS
     ) as executor:
         ws = executor.map(_read_window, sources)
 

--- a/marblecutter/recipes.py
+++ b/marblecutter/recipes.py
@@ -239,7 +239,8 @@ def postprocess(windows):
 
     windows = list(filter(None, windows))
 
-    landsat_windows = filter(lambda sw: "LC08_" in sw[0].url, windows)
+    # wrap url in str because url could be None
+    landsat_windows = filter(lambda sw: "LC08_" in str(sw[0].url), windows)
     landsat_windows = dict(
         [
             (k, list(v))

--- a/marblecutter/utils.py
+++ b/marblecutter/utils.py
@@ -25,11 +25,12 @@ Source = namedtuple(
         "filename",
         "min_zoom",
         "max_zoom",
-        "expr"
+        "expr",
+        "pixels"
     ],
 )
 Source.__new__.__defaults__ = (
-    {}, {}, {}, None, None, None, None, None, None, None, None, None, None
+    {}, {}, {}, None, None, None, None, None, None, None, None, None, None, None
 )
 
 


### PR DESCRIPTION
Hello, again.  This pull request adds the **pixels** attribute to the NamedTuple **Source**.  This allows people to fetch the data for their source outside of marblecutter and hold it in memory.  Although this isn't often the case, there are a couple use cases I came across:
- Programmatically creating a source when different bands are split among multiple files
- Creating a source from a file with a format or protocol that isn't supported by rasterio

I'll also be submitting a pull request to marblecutter-virtual, which uses **pixels** and supports creating tiles from a SpatioTemporal Asset Catalog, including with band arithmetic.

Happy to receive feedback and re-submit if you have any changes that you would like to see.

Thank you for your consideration.